### PR TITLE
Remove extraneous slashes that give 403 Forbidden

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,12 +16,11 @@ module Terraform
     # Downloads the raw checksums from hashicorp
     # https://releases.hashicorp.com/terraform/#{version}/#{checksum_file}
     def fetch_checksums
-      require 'uri'
       uri = URI.parse(node['terraform']['url_base'])
-      terraform_releases = "#{uri.scheme}://#{uri.host}/"
+      terraform_releases = "#{uri.scheme}://#{uri.host}"
       version = node['terraform']['version']
       checksum_file = "terraform_#{version}_SHA256SUMS"
-      path = "#{uri.path}/#{version}/#{checksum_file}"
+      path = "terraform/#{version}/#{checksum_file}"
       Chef::HTTP::Simple.new(terraform_releases).get(path)
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,12 +16,9 @@ module Terraform
     # Downloads the raw checksums from hashicorp
     # https://releases.hashicorp.com/terraform/#{version}/#{checksum_file}
     def fetch_checksums
-      uri = URI.parse(node['terraform']['url_base'])
-      terraform_releases = "#{uri.scheme}://#{uri.host}"
       version = node['terraform']['version']
-      checksum_file = "terraform_#{version}_SHA256SUMS"
-      path = "terraform/#{version}/#{checksum_file}"
-      Chef::HTTP::Simple.new(terraform_releases).get(path)
+      uri = URI.join(node['terraform']['url_base'], "#{version}/terraform_#{version}_SHA256SUMS")
+      Chef::HTTP::Simple.new("#{uri.scheme}://#{uri.host}").get(uri.path.to_s)
     end
 
     def terraform_url


### PR DESCRIPTION
Hashicorp release URLs with double-slashes in them now give 403 Forbidden:

```
$ curl https://releases.hashicorp.com//terraform/0.6.11/terraform_0.6.11_SHA256SUMS
<html>
<head><title>403 Forbidden</title></head>
<body>
<h1>403 Forbidden</h1>
<ul>
<li>Code: AccessDenied</li>
<li>Message: Access Denied</li>
<li>RequestId: CAFEA26554219401</li>
<li>HostId: eIj823l/dJPC0MMcedr1HhTYTmR8suF2IBuP6paoze6+FV8MYdWkwb682/1sXC4Db3yjI7DRNJU=</li>
</ul>
<hr/>
</body>
</html>
```

This patch:
* Trims the trailing slash from `terraform_releases`
* Trims the leading slash from `uri.path`
* Trims the `require 'uri'` since I noticed Chef::HTTP::Simple already required it

Tested good in my local environment.