### PR TITLE
Zipfile fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,8 +9,6 @@ platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: debian-8.6
-#  - name: debian-7.10 # lib6 too old for chef?
-#  - name: debian-7.11 # lib6 too old for chef?
   - name: centos-7.2
   - name: centos-6.7
   - name: fedora-21

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,9 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: debian-8.4
-  - name: debian-7.10
+  - name: debian-8.6
+#  - name: debian-7.10 # lib6 too old for chef?
+#  - name: debian-7.11 # lib6 too old for chef?
   - name: centos-7.2
   - name: centos-6.7
   - name: fedora-21

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -24,7 +24,7 @@ GRAPH
     compat_resource (>= 12.14.7)
   seven_zip (2.0.2)
     windows (>= 1.2.2)
-  terraform (1.0.0)
+  terraform (1.0.1)
     ark (~> 2.0)
     build-essential (~> 7.0)
   windows (2.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 terraform Cookbook CHANGELOG
 ============================
 
+1.0.1
+-----
+- update to handle new host folder structure at terraform
+
 1.0.0
 -----
 - update ark dependency: ~> 2.0 (Now requires Chef 12.5+)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,9 +6,6 @@ default['terraform']['arch'] = if node['kernel']['machine'] =~ /x86_64/
                                  '386'
                                end
 
-default['terraform']['zipfile'] = "terraform_#{node['terraform']['version']}_" \
-  "#{node['os']}_#{node['terraform']['arch']}.zip"
-
 # Windows attributes
 default['terraform']['win_install_dir'] = 'C:\terraform'
 default['terraform']['owner'] = 'Administrator'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,9 @@ default['terraform']['arch'] = if node['kernel']['machine'] =~ /x86_64/
                                  '386'
                                end
 
+default['terraform']['zipfile'] = "terraform_#{node['terraform']['version']}_" \
+  "#{node['os']}_#{node['terraform']['arch']}.zip"
+
 # Windows attributes
 default['terraform']['win_install_dir'] = 'C:\terraform'
 default['terraform']['owner'] = 'Administrator'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,11 +60,11 @@ module Terraform
     # See https://coderanger.net/derived-attributes/
     # for why this is the way it is
     def terraform_url
-      base = URI.parse(node['terraform']['url_base'])
       version = node['terraform']['version']
-      zipfile = "terraform_#{node['terraform']['version']}_" \
+      base = URI.parse(node['terraform']['url_base']+"/#{version}")
+      zipfile = "terraform_#{version}_" \
                 "#{node['os']}_#{node['terraform']['arch']}.zip"
-      "#{base}/#{version}/#{node['terraform']['zipfile']}"
+      "#{base}/#{zipfile}"
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -62,6 +62,8 @@ module Terraform
     def terraform_url
       base = URI.parse(node['terraform']['url_base'])
       version = node['terraform']['version']
+      zipfile = "terraform_#{node['terraform']['version']}_" \
+                "#{node['os']}_#{node['terraform']['arch']}.zip"
       "#{base}/#{version}/#{node['terraform']['zipfile']}"
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'ross@rosstimson.com'
 license          'Apache 2.0'
 description      'Installs Terraform (terraform.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 depends 'ark', '~> 2.0'
 depends 'build-essential', '~> 7.0'


### PR DESCRIPTION
It appears terraform has adjusted the directory structure for how they host things. 

This pull request updates the terraform_url function to return the new path.

It also removes the attribute ['terraform']['zipfile'] and puts that logic back into terraform_url function.

This means people can specify the version of terraform in their own cookbooks and have all the parts align around them overriding that one attribute.  This means both the zip file and the SHA1 resolve correctly.

I did not rev the default version of terraform it installs to 0.8.5 as not doing that was part of the logic I wanted to test (letting my cookbook specify a newer version than this cookbook).

